### PR TITLE
Revise NestJS rules and workflows

### DIFF
--- a/.agent/rules/rules.md
+++ b/.agent/rules/rules.md
@@ -1,0 +1,47 @@
+# NestJS Rules (Edradop Monorepo)
+
+This repository is a NestJS monorepo. Keep the existing structure and follow the rules below.
+
+## Repository Layout
+- Applications live in `apps/<app>/src`.
+- Shared libraries live in `libs/common` and `libs/config`.
+- Use path aliases: `@edd/common` and `@edd/config`.
+
+## Application Structure
+- `apps/<app>/src/main.ts` is the application entry.
+- The root module is `<app>.module.ts`.
+- Application folders:
+  - `controller/` → HTTP/transport layer.
+  - `service/` → business logic.
+  - `module/` → feature modules.
+  - `guard/`, `pipe/`, `filter/`, `middleware/` → cross-cutting concerns.
+- Use `index.ts` barrel files in folders and import from them.
+
+## Feature Module Structure
+- Features live under `module/<feature>/`.
+- Each feature module contains:
+  - `<feature>.module.ts`
+  - `controller/`, `service/`
+  - `index.ts` barrel file
+- Public exports must go through `index.ts`.
+
+## CLI Usage
+- Use Nest CLI to generate framework files (modules, controllers, services, guards, pipes, filters, middleware, apps, libs).
+- Prefer `pnpm nest g ...` with `--project <app>` in the monorepo.
+
+## Code Standards
+- File and folder names use `kebab-case`.
+- Class names use `PascalCase`, variables/functions use `camelCase`.
+- Filenames must follow `*.controller.ts`, `*.service.ts`, `*.module.ts`.
+- Tests live next to the implementation as `*.spec.ts`.
+- Shared configuration belongs in `libs/config`; new keys go under `libs/config/src/constant`.
+
+## Dependencies and DI
+- Use `@edd/common` for shared helpers beyond `@nestjs/*`.
+- Use NestJS decorators (`@Injectable`, `@Module`, `@Controller`) consistently.
+- Prefer `EnvironmentModule` and `register*Module` helpers for configuration.
+
+## Monorepo Consistency
+- When adding a new app or lib, update `nest-cli.json` `projects`.
+- When adding a new lib, update `tsconfig.json` `paths`.
+- Do not change top-level directory structure.

--- a/.agent/workflows/add-cache.md
+++ b/.agent/workflows/add-cache.md
@@ -1,0 +1,15 @@
+# Workflow: Add Cache Integration
+
+## Goal
+Enable cache support in an application.
+
+## Steps
+1. Add `registerCacheModule()` to the root module imports.
+2. Add any required config/env keys.
+3. Inject cache in services where needed.
+4. Add or update tests.
+
+## Checklist
+- [ ] Cache module imported.
+- [ ] Config keys added.
+- [ ] Usage verified.

--- a/.agent/workflows/add-common-constant.md
+++ b/.agent/workflows/add-common-constant.md
@@ -1,0 +1,14 @@
+# Workflow: Add Shared Constant
+
+## Goal
+Add a shared constant to `libs/common`.
+
+## Steps
+1. Add the constant under `libs/common/src/constant/`.
+2. Export it from `libs/common/src/index.ts`.
+3. Use the constant via `@edd/common`.
+
+## Checklist
+- [ ] Constant is under `libs/common/src/constant/`.
+- [ ] `index.ts` export updated.
+- [ ] Usage imports from `@edd/common`.

--- a/.agent/workflows/add-common-type.md
+++ b/.agent/workflows/add-common-type.md
@@ -1,0 +1,14 @@
+# Workflow: Add Shared Type
+
+## Goal
+Add a shared type definition to `libs/common`.
+
+## Steps
+1. Add the type under `libs/common/src/type/`.
+2. Export it from `libs/common/src/index.ts`.
+3. Use the type via `@edd/common`.
+
+## Checklist
+- [ ] Type lives under `libs/common/src/type/`.
+- [ ] `index.ts` export updated.
+- [ ] Usage imports from `@edd/common`.

--- a/.agent/workflows/add-config-key.md
+++ b/.agent/workflows/add-config-key.md
@@ -1,0 +1,14 @@
+# Workflow: Add Config Key
+
+## Goal
+Add a new configuration key.
+
+## Steps
+1. Add the key to `libs/config/src/constant/keys.constant.ts`.
+2. Add the default value to `libs/config/src/constant/default.constant.ts`.
+3. Update any config module wiring if required.
+4. Import the key via `@edd/config` in usage sites.
+
+## Checklist
+- [ ] Keys and defaults updated.
+- [ ] Usage imports from `@edd/config`.

--- a/.agent/workflows/add-config-util.md
+++ b/.agent/workflows/add-config-util.md
@@ -1,0 +1,15 @@
+# Workflow: Add Config Utility
+
+## Goal
+Add a new config helper under `libs/config`.
+
+## Steps
+1. Create the util under `libs/config/src/util/` (or a subfolder).
+2. Export it from `libs/config/src/util/index.ts`.
+3. Export from `libs/config/src/index.ts` if it should be public.
+4. Use the helper via `@edd/config`.
+
+## Checklist
+- [ ] Util added under `libs/config/src/util/`.
+- [ ] `util/index.ts` export updated.
+- [ ] Public export added when needed.

--- a/.agent/workflows/add-database-integration.md
+++ b/.agent/workflows/add-database-integration.md
@@ -1,0 +1,15 @@
+# Workflow: Add Database Integration
+
+## Goal
+Wire a database module for an app.
+
+## Steps
+1. Add or update the database register util under `libs/config/src/util/database/`.
+2. Export it from `libs/config/src/util/index.ts`.
+3. Import the register util in the app module and add it to `imports`.
+4. Add required config keys and defaults.
+
+## Checklist
+- [ ] Database register util exists and is exported.
+- [ ] App module imports updated.
+- [ ] Config keys/defaults added.

--- a/.agent/workflows/add-dto.md
+++ b/.agent/workflows/add-dto.md
@@ -1,0 +1,15 @@
+# Workflow: Add DTO
+
+## Goal
+Add a Data Transfer Object for a feature.
+
+## Steps
+1. Create a `dto/` folder under the feature if it doesn't exist.
+2. Add the DTO class file inside `dto/`.
+3. Add validation decorators if required.
+4. Export the DTO from the feature `index.ts`.
+
+## Checklist
+- [ ] DTO lives under the feature.
+- [ ] Validation decorators added when needed.
+- [ ] Barrel exports updated.

--- a/.agent/workflows/add-e2e-test.md
+++ b/.agent/workflows/add-e2e-test.md
@@ -1,0 +1,15 @@
+# Workflow: Add E2E Test
+
+## Goal
+Add an end-to-end test scenario.
+
+## Steps
+1. Create the e2e test under `apps/<app>/test/`.
+2. Add app bootstrap and teardown logic.
+3. Verify HTTP interactions.
+4. Run `pnpm run test:e2e`.
+
+## Checklist
+- [ ] Test file lives under `apps/<app>/test/`.
+- [ ] Bootstrap/teardown present.
+- [ ] E2E tests pass.

--- a/.agent/workflows/add-env-var.md
+++ b/.agent/workflows/add-env-var.md
@@ -1,0 +1,14 @@
+# Workflow: Add Environment Variable
+
+## Goal
+Define a new environment variable.
+
+## Steps
+1. Add the key to `libs/config/src/constant/keys.constant.ts`.
+2. Add the default value to `libs/config/src/constant/default.constant.ts`.
+3. Document it in `.example.env`.
+4. Access it through `@edd/config` in code.
+
+## Checklist
+- [ ] Key and default value added.
+- [ ] `.example.env` updated.

--- a/.agent/workflows/add-feature-index.md
+++ b/.agent/workflows/add-feature-index.md
@@ -1,0 +1,14 @@
+# Workflow: Add Feature Barrel Export
+
+## Goal
+Expose a feature module's public API through a barrel file.
+
+## Steps
+1. Create or update `apps/<app>/src/module/<feature>/index.ts`.
+2. Export the feature module and any public DTOs or services.
+3. Update imports inside the app to use the feature barrel.
+
+## Checklist
+- [ ] `index.ts` exists under the feature.
+- [ ] Public exports defined.
+- [ ] Imports use the barrel file.

--- a/.agent/workflows/add-health-endpoint.md
+++ b/.agent/workflows/add-health-endpoint.md
@@ -1,0 +1,15 @@
+# Workflow: Add Health Endpoint
+
+## Goal
+Add a simple health endpoint to an app.
+
+## Steps
+1. Generate a health controller with Nest CLI:
+   - `pnpm nest g controller health --project <app-name>`
+2. Add a `GET /health` route that returns a minimal payload.
+3. Add a unit test for the controller.
+
+## Checklist
+- [ ] Health controller generated with Nest CLI.
+- [ ] `GET /health` responds with a simple payload.
+- [ ] Unit test added.

--- a/.agent/workflows/add-microservice-client.md
+++ b/.agent/workflows/add-microservice-client.md
@@ -1,0 +1,16 @@
+# Workflow: Add Microservice Client
+
+## Goal
+Register a new microservice client.
+
+## Steps
+1. Add a register function under `libs/config/src/util/client-proxy/`.
+2. Export it from `libs/config/src/util/index.ts`.
+3. Register the client with `ClientsModule.registerAsync` in the app module.
+4. Inject the client token in the consuming service.
+5. Add config/env keys if required.
+
+## Checklist
+- [ ] Client register util added and exported.
+- [ ] Module imports updated.
+- [ ] Token usage verified.

--- a/.agent/workflows/add-minio-integration.md
+++ b/.agent/workflows/add-minio-integration.md
@@ -1,0 +1,15 @@
+# Workflow: Add MinIO Integration
+
+## Goal
+Enable MinIO storage in an app.
+
+## Steps
+1. Ensure `registerMinioModule` exists in `libs/config/src/util/`.
+2. Import `registerMinioModule()` in the app root module.
+3. Add MinIO config keys and defaults if missing.
+4. Inject and use the MinIO client in services as needed.
+
+## Checklist
+- [ ] MinIO module registered in the app.
+- [ ] Config keys/defaults present.
+- [ ] Service usage verified.

--- a/.agent/workflows/add-route.md
+++ b/.agent/workflows/add-route.md
@@ -1,0 +1,16 @@
+# Workflow: Add Route
+
+## Goal
+Add a new route to an existing controller.
+
+## Steps
+1. Locate the controller under `controller/*.controller.ts`.
+2. Add the new route handler method with the correct decorator.
+3. Add or update the matching service method.
+4. Add DTOs and validation if required.
+5. Update or add tests.
+
+## Checklist
+- [ ] Controller and service methods align.
+- [ ] DTOs/validation complete if needed.
+- [ ] Tests updated.

--- a/.agent/workflows/add-shared-util.md
+++ b/.agent/workflows/add-shared-util.md
@@ -1,0 +1,15 @@
+# Workflow: Add Shared Utility
+
+## Goal
+Add a shared utility function.
+
+## Steps
+1. Create a new file under `libs/common/src/util/`.
+2. Export it from `libs/common/src/index.ts`.
+3. Import it via `@edd/common` in usage sites.
+4. Add tests if needed.
+
+## Checklist
+- [ ] Utility lives in `libs/common`.
+- [ ] `index.ts` export updated.
+- [ ] Imports use the alias.

--- a/.agent/workflows/add-unit-test.md
+++ b/.agent/workflows/add-unit-test.md
@@ -1,0 +1,15 @@
+# Workflow: Add Unit Test
+
+## Goal
+Add or update a unit test.
+
+## Steps
+1. Place the test next to the implementation as `*.spec.ts`.
+2. Use the NestJS testing module to mock dependencies.
+3. Add assertions for the main scenarios.
+4. Run `pnpm run test`.
+
+## Checklist
+- [ ] Test file placed correctly.
+- [ ] Mocks and setup complete.
+- [ ] Tests pass.

--- a/.agent/workflows/add-validation.md
+++ b/.agent/workflows/add-validation.md
@@ -1,0 +1,13 @@
+# Workflow: Add Validation
+
+## Goal
+Add or tighten validation for an existing route or DTO.
+
+## Steps
+1. Add `class-validator` decorators to the DTO fields.
+2. Ensure `ValidationPipe` is enabled (globally or at route level).
+3. Standardize error messages if required.
+
+## Checklist
+- [ ] DTO validation decorators added.
+- [ ] `ValidationPipe` is active.

--- a/.agent/workflows/new-app.md
+++ b/.agent/workflows/new-app.md
@@ -1,0 +1,18 @@
+# Workflow: New App
+
+## Goal
+Add a new NestJS application to the monorepo.
+
+## Steps
+1. Generate the app with Nest CLI:
+   - `pnpm nest g app <app-name>`
+2. Verify `apps/<app-name>/src/main.ts` and `<app-name>.module.ts` exist.
+3. Ensure default folders exist: `controller/`, `service/`, `module/`, `guard/`, `pipe/`, `filter/`, `middleware/`.
+4. Add barrel files (`index.ts`) in `controller/` and `service/` if missing.
+5. Confirm `nest-cli.json` contains the new app entry.
+
+## Checklist
+- [ ] `apps/<app-name>/src/main.ts` exists.
+- [ ] `<app-name>.module.ts` is the root module.
+- [ ] `nest-cli.json` updated.
+- [ ] Barrel files created.

--- a/.agent/workflows/new-feature.md
+++ b/.agent/workflows/new-feature.md
@@ -1,0 +1,19 @@
+# Workflow: New Feature Module
+
+## Goal
+Create a new feature area inside an app.
+
+## Steps
+1. Generate the feature module:
+   - `pnpm nest g module module/<feature> --project <app-name>`
+2. Generate a feature controller and service:
+   - `pnpm nest g controller module/<feature>/controller --project <app-name>`
+   - `pnpm nest g service module/<feature>/service --project <app-name>`
+3. Add a feature `index.ts` barrel file under `module/<feature>/` and export the module.
+4. Import the feature module into `<app-name>.module.ts`.
+
+## Checklist
+- [ ] Feature module lives under `module/<feature>`.
+- [ ] Controller/service generated with Nest CLI.
+- [ ] `index.ts` exports the module.
+- [ ] Root module imports updated.

--- a/.agent/workflows/new-lib.md
+++ b/.agent/workflows/new-lib.md
@@ -1,0 +1,16 @@
+# Workflow: New Library
+
+## Goal
+Add a shared library under `libs/`.
+
+## Steps
+1. Generate the library with Nest CLI:
+   - `pnpm nest g lib <lib-name>`
+2. Ensure `libs/<lib-name>/src/index.ts` exists.
+3. Update `tsconfig.json` `paths` with the new alias if needed.
+4. Confirm `nest-cli.json` includes the new library project.
+
+## Checklist
+- [ ] `libs/<lib-name>/src/index.ts` exists.
+- [ ] `nest-cli.json` updated.
+- [ ] `tsconfig.json` `paths` updated.


### PR DESCRIPTION
### Motivation
- Translate repository rules and workflow guidance into English for clarity and consistency.
- Require and document using the Nest CLI when creating NestJS artifacts by referencing `pnpm nest g ...` and `--project <app>` in the monorepo.
- Remove workflows that describe artifacts already produced by the Nest CLI and replace them with custom workflows for non-CLI tasks.
- Preserve existing repo layout and aliases such as `@edd/common` and `@edd/config` while improving onboarding guidance.

### Description
- Add an English rules document at `.agent/rules/rules.md` that documents repo layout, feature structure, code standards, and explicit Nest CLI usage (`pnpm nest g ...`).
- Create and update 20 workflow guides under `.agent/workflows/`, converting content to English and aligning steps to Nest CLI generation where appropriate (for example `new-app.md`, `new-lib.md`, `new-feature.md`, and others).
- Remove workflows for Nest-generated artifacts and replace them with custom guidance; removed files include `new-controller.md`, `new-service.md`, `new-module.md`, `new-guard.md`, `new-pipe.md`, `new-filter.md`, and `new-middleware.md`.
- Add custom workflows for repository-specific tasks such as `add-feature-index.md`, `add-health-endpoint.md`, `add-config-util.md`, and `add-database-integration.md` and update other workflows to reference the CLI (`pnpm nest g ...`) where generation is appropriate.

### Testing
- No automated tests were executed because these changes are documentation-only.
- No linting or CI builds were run as part of this PR since the modifications only update guidance files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ec0cf9484832ea56c0c67594025f0)